### PR TITLE
feat: allow for a custom postcss version to be passed

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
   "peerDependencies": {
     "postcss": "^8.2.2"
   },
+  "peerDependenciesMeta": {
+    "postcss": {
+      "optional": true
+    }
+  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
-const postcss = require('postcss');
 const createSimplePreset = require('cssnano-preset-simple');
 
-module.exports = (opts = {}) => {
+module.exports = (opts = {}, postcss = require('postcss')) => {
   const excludeAll = Boolean(opts && opts.excludeAll);
 
   const userOpts = Object.assign({}, opts);


### PR DESCRIPTION
For some reason npm does not resolve peerdeps of a dependency correctly when there's conflicts. This ensures Next.js always provides the version of postcss.
